### PR TITLE
feat: add regex custom managers

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,5 +11,28 @@
   ],
   "vulnerabilityAlerts": {
     "labels": ["security"]
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update _VERSION variables in Dockerfiles",
+      "fileMatch": [
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile\\.[^/]*$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update _VERSION variables in GitHub Actions",
+      "fileMatch": [
+        "^\\.github/.*\\.ya?ml$",
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_VERSION: (?<currentValue>.+?)\\s"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds regex custom managers to update `*_VERSION` variables in Dockerfiles and GitHub Actions.

ref: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture

### Examples

#### Dockerfile

```dockerfile
# renovate: datasource=github-tags depName=node packageName=nodejs/node versioning=node
ENV NODE_VERSION=20.10.0


# renovate: datasource=go packageName=go.opentelemetry.io/collector/cmd/builder versioning=semver
ARG OCB_VERSION=v0.121.0
```

#### GitHub Actions

```yaml
      - name: Install OpenTelemetry Collector Builder
        run: |
          go install "go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION}"
        env:
          # renovate: datasource=go packageName=go.opentelemetry.io/collector/cmd/builder versioning=semver
          OCB_VERSION: v0.121.0
```
