### PR TITLE
fix: remove invalid trailing comma

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,7 +28,7 @@
       "customType": "regex",
       "description": "Update _VERSION variables in GitHub Actions",
       "fileMatch": [
-        "^\\.github/.*\\.ya?ml$",
+        "^\\.github/.*\\.ya?ml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_VERSION: (?<currentValue>.+?)\\s"


### PR DESCRIPTION
This pull request just removes invalid trailing comma.

I mistakenly added a trailing comma in the `fileMatch` array in the `default.json` file on the pull request https://github.com/tailor-inc/renovate-config/pull/2.
It's causing the following error:

> File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.
