### PR TITLE
feat: add "npm:unpublishSafe" preset to extends

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    ":approveMajorUpdates"
+    ":approveMajorUpdates",
+    "npm:unpublishSafe"
   ],
   "postUpdateOptions": [
     "gomodTidy",


### PR DESCRIPTION
This pull request adds `npm:unpublishSafe` preset to extends.

refs:
- https://docs.renovatebot.com/presets-npm/
- https://docs.renovatebot.com/configuration-options/#prevent-holding-broken-npm-packages
  > npm packages less than 72 hours (3 days) old can be unpublished from the npm registry, which could result in a service impact if you have already updated to it. Set minimumReleaseAge to 3 days for npm packages to prevent relying on a package that can be removed from the registry...
