### PR TITLE
chore: update preset name from "npm:unpublishSafe" to "security:minimumReleaseAgeNpm"

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:best-practices",
     ":approveMajorUpdates",
-    "npm:unpublishSafe"
+    "security:minimumReleaseAgeNpm"
   ],
   "postUpdateOptions": [
     "gomodTidy",


### PR DESCRIPTION
## WHAT

This pull request updates Renovate preset name from `npm:unpublishSafe` to `security:minimumReleaseAgeNpm`.

## WHY

- https://github.com/renovatebot/renovate/pull/38240
- https://github.com/renovatebot/renovate/pull/38310

## NOTE

- https://github.com/renovatebot/renovate/issues/38478
